### PR TITLE
Don't install `pry` in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ ruby "2.5.0"
 gem "pg"
 gem "activerecord"
 gem "poltergeist"
-gem "pry"
 
 group :development do
   gem "dotenv"


### PR DESCRIPTION
Bundler was complaining:

```
 Your Gemfile lists the gem pry (>= 0) more than once.
 You should probably keep only one of them.
 While it's not a problem now, it could cause errors if you change the version
of one of them later.
```

and we shouldn't have debugging tools like pry available in production anyway.