### PR TITLE
Use SQLite in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,5 @@ gem "pry"
 
 group :development do
   gem "sqlite3"
-  gem "dotenv"
   gem "pry"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "poltergeist"
 gem "pry"
 
 group :development do
+  gem "sqlite3"
   gem "dotenv"
   gem "pry"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,6 @@ GEM
     cliver (0.3.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
-    dotenv (2.2.1)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     method_source (0.9.0)
@@ -61,7 +60,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord
-  dotenv
   pg
   poltergeist
   pry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
     rack (2.0.4)
     rack-test (0.8.3)
       rack (>= 1.0, < 3)
+    sqlite3 (1.3.13)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -64,6 +65,7 @@ DEPENDENCIES
   pg
   poltergeist
   pry
+  sqlite3
 
 RUBY VERSION
    ruby 2.5.0p0

--- a/README.md
+++ b/README.md
@@ -91,39 +91,18 @@ instrument failures etc
 
 ### Dependencies
 
-* PostgreSQL
 * PhantomJS
-
-### Database setup
-
-Replace `$password` with your own strong database password.
-
-```
-createdb westconnex_m4east_aqm_development
-psql westconnex_m4east_aqm_development
-> CREATE ROLE westconnex_m4east_aqm;
-> ALTER ROLE westconnex_m4east_aqm WITH LOGIN PASSWORD '$password' NOSUPERUSER NOCREATEDB NOCREATEROLE;
-> CREATE DATABASE westconnex_m4east_aqm_development OWNER westconnex_m4east_aqm;
-> REVOKE ALL ON DATABASE westconnex_m4east_aqm_development FROM PUBLIC;
-> GRANT ALL ON DATABASE westconnex_m4east_aqm_development TO westconnex_m4east_aqm;
-> \q
-```
-
-When running the scrapers, add the environment varaible
-DEVELOPMENT_DATABASE_PASSWORD with the same value as `$password` above, to use
-the password when running the scraper. Create a file `.env` and add the
-variable:
-
-```
-# .env
-
-DEVELOPMENT_DATABASE_PASSWORD=$password
-```
+* PostgreSQL in production
+* SQLite in development
 
 ### Running locally
 
 ```
-bundle exec dotenv ruby scraper.rb
+# Install gem dependencies
+bundle install
+
+# Run the scraper
+bundle exec ruby scraper.rb
 ```
 
 ## Production Setup

--- a/database_config.rb
+++ b/database_config.rb
@@ -1,10 +1,4 @@
-DEV_DATABASE_CONFIG = {
-  adapter: 'postgresql',
-  host: 'localhost',
-  username: 'westconnex_m4east_aqm',
-  password: ENV['DEVELOPMENT_DATABASE_PASSWORD'],
-  database: 'westconnex_m4east_aqm_development'
-}.freeze
+DEV_DATABASE_CONFIG = {adapter: 'sqlite3', database: 'data.sqlite'}.freeze
 
 def environment
   ENV['SCRIPT_ENV'] == 'production' ?  :production : :development


### PR DESCRIPTION
Make it easier to get up and running in development as SQLite is easier
to set up than Postgres.

I can see how this could be a contentious change. Maybe the intent was in fact
to use PostgreSQL to ensure complete parity between development and production?
If so I'm happy for this and the associated issue to be closed :zap:

Fixes #7.