### PR TITLE
Use RACK_ENV instead of SCRIPT_ENV to detect production mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,12 @@ heroku buildpacks:add --index 1 https://github.com/stomita/heroku-buildpack-phan
 
 ### Running in production
 
-In production, run the script with the environment variables
-`SCRIPT_ENV=production`.
+The script runs in production when the `RACK_ENV` environment variable is set to
+"production". This is automatically set on Heroku but you can test it locally by
+running:
 
 ```
-SCRIPT_ENV=production be ruby scraper.rb
+RACK_ENV=production be ruby scraper.rb
 ```
 
 Heroku injects it's own `ENV['DATABASE_URL']`.

--- a/database_config.rb
+++ b/database_config.rb
@@ -7,7 +7,7 @@ DEV_DATABASE_CONFIG = {
 }.freeze
 
 def environment
-  ENV['SCRIPT_ENV'] == 'production' ?  :production : :development
+  ENV['RACK_ENV'] == 'production' ?  :production : :development
 end
 
 def production_db_config


### PR DESCRIPTION
RACK_ENV is automatically set on Heroku to "production" and it's a common
method of switching environments.

This change makes commands easier to run as the developer doesn't have to
manually set the SCRIPT_ENV in most circumstances. It will also allow us to
set up other environments (like "test") quite easily.

Fixes #4.