### PR TITLE
Configure Travis CI to automatically test application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+services:
+  - postgresql
+before_script:
+  - psql -c 'create database travis_ci_test;' -U postgres

--- a/database.rb
+++ b/database.rb
@@ -1,10 +1,12 @@
 require 'active_record'
 
 def database_config
-  case ENV['RACK_ENV']
-  when 'production'
+  case
+  when ENV['RACK_ENV'] == 'production'
     ENV['DATABASE_URL']
-  when 'test'
+  when ENV['RACK_ENV'] == 'test' && ENV['TRAVIS'] == 'true'
+    {adapter: 'postgresql', database: 'travis_ci_test'}
+  when ENV['RACK_ENV'] == 'test'
     {
       adapter: 'postgresql',
       host: 'localhost',
@@ -12,7 +14,7 @@ def database_config
       password: ENV['DEVELOPMENT_DATABASE_PASSWORD'],
       database: 'westconnex_m4east_aqm_test'
     }
-  else
+  else # development
     {
       adapter: 'postgresql',
       host: 'localhost',


### PR DESCRIPTION
This includes a new (another one!) database configuration for Travis and a Travis configuration file that enables PostgreSQL and creates the test database.

I don't have admin privileges on the repo so @equivalentideas will need to go to https://travis-ci.org/equivalentideas/westconnex_M4_East_Air_Quality_Monitoring and enable Travis.