### PR TITLE
Disable Ruby warnings in test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ task default: %w[test rubocop]
 Rake::TestTask.new do |t|
   t.pattern = 'test/*_test.rb'
   t.libs << 'test'
+  t.warning = false
 end
 
 RuboCop::RakeTask.new


### PR DESCRIPTION
This disables warnings from Ruby when running the test suite. Prior to
this change when running the tests you'd get warnings like these:

```
  RUBY_GC_MALLOC_LIMIT=59000000 (default value: 16777216)
  /home/henare/.rvm/gems/ruby-2.5.0/gems/activesupport-5.1.5/lib/active_support/core_ext/hash/slice.rb:21: warning: method redefined; discarding old slice
  /home/henare/.rvm/gems/ruby-2.5.0/gems/arel-8.0.0/lib/arel/visitors/informix.rb:21: warning: assigned but unused variable - froms
```

This change suppresses these warnings because we don't care about issues
like these in our gem dependencies.