### PR TITLE
Fix some Rubocop TODOs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,6 @@
 inherit_from: .rubocop_todo.yml
+
+# Minitest specs have long blocks so exclude them from the BlockLength check
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,11 +12,6 @@ Metrics/MethodLength:
   Max: 21
 
 # Offense count: 1
-Style/MixinUsage:
-  Exclude:
-    - 'test/test_helper.rb'
-
-# Offense count: 1
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Metrics/LineLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,11 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 3
-# Configuration parameters: CountComments, ExcludedMethods.
-Metrics/BlockLength:
-  Max: 47
-
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/MethodLength:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,8 +5,12 @@ require 'minitest/autorun'
 require 'rack/test'
 require_relative '../app'
 
-include Rack::Test::Methods
+module Minitest
+  class Spec
+    include Rack::Test::Methods
 
-def app
-  Sinatra::Application
+    def app
+      Sinatra::Application
+    end
+  end
 end


### PR DESCRIPTION
This fixes an easy Rubocop todo and deliberately excludes one check we don't want to run.