### PR TITLE
Switch from ActiveRecord to Sequel and start using migrations to change the database schema

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 inherit_from: .rubocop_todo.yml
 
-# Minitest specs have long blocks so exclude them from the BlockLength check
+# Minitest specs and Sequel migrations have long blocks so exclude them from the
+# BlockLength check
 Metrics/BlockLength:
   Exclude:
     - 'test/**/*'
+    - 'db/migrations/**/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ services:
   - postgresql
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
+  - bundle exec rake db:migrate

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'activerecord'
 gem 'pg'
 gem 'poltergeist'
 gem 'rake'
+gem 'sequel'
 gem 'sinatra'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
+    sequel (5.7.1)
     sinatra (2.0.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -91,6 +92,7 @@ DEPENDENCIES
   pry
   rake
   rubocop
+  sequel
   sinatra
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ psql westconnex_m4east_aqm_development
 > REVOKE ALL ON DATABASE westconnex_m4east_aqm_development FROM PUBLIC;
 > GRANT ALL ON DATABASE westconnex_m4east_aqm_development TO westconnex_m4east_aqm;
 > \q
+bundle exec rake db:migrate
 ```
 
 When running the scrapers, add the environment varaible

--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ variable:
 DEVELOPMENT_DATABASE_PASSWORD=$password
 ```
 
+#### Migrating/changing the database
+
+To make changes to the database we're using
+[Sequel](http://sequel.jeremyevans.net/)'s
+[migrations](http://sequel.jeremyevans.net/rdoc/files/doc/migration_rdoc.html).
+The Sequel documentation has details on how to create new migrations and you can
+see examples in our `db/migrations` directory.
+
+You can use
+[Sequel's command line tool](http://sequel.jeremyevans.net/rdoc/files/doc/migration_rdoc.html#label-Running+migrations)
+to perform the migrations or our Rake task:
+
+```
+bundle exec dotenv rake db:migrate
+```
+
 ### Running locally
 
 #### Scraper

--- a/Rakefile
+++ b/Rakefile
@@ -12,3 +12,18 @@ Rake::TestTask.new do |t|
 end
 
 RuboCop::RakeTask.new
+
+namespace :db do
+  desc 'Run database migrations'
+  task :migrate, [:version] do |_t, args|
+    require './db/connection'
+    Sequel.extension :migration
+    if args[:version]
+      puts "Migrating database to version #{args[:version]}"
+      Sequel::Migrator.run(DB, 'db/migrations', target: args[:version].to_i)
+    else
+      puts 'Migrating database to latest version'
+      Sequel::Migrator.run(DB, 'db/migrations')
+    end
+  end
+end

--- a/app.rb
+++ b/app.rb
@@ -13,9 +13,9 @@ get '/csv' do
   content_type 'application/csv'
   attachment 'aqm_records.csv'
   CSV.generate do |csv|
-    csv << AqmRecord.attribute_names # Add header row
+    csv << AqmRecord.columns # Add header row
     AqmRecord.all.each do |record|
-      csv << record.attributes.values
+      csv << record.values.values
     end
   end
 end

--- a/database.rb
+++ b/database.rb
@@ -1,31 +1,5 @@
 # frozen_string_literal: true
 
-require 'sequel'
-
-def database_config
-  if ENV['RACK_ENV'] == 'production'
-    ENV['DATABASE_URL']
-  elsif ENV['RACK_ENV'] == 'test' && ENV['TRAVIS'] == 'true'
-    { adapter: 'postgresql', database: 'travis_ci_test' }
-  elsif ENV['RACK_ENV'] == 'test'
-    {
-      adapter: 'postgresql',
-      host: 'localhost',
-      username: 'westconnex_m4east_aqm',
-      password: ENV['DEVELOPMENT_DATABASE_PASSWORD'],
-      database: 'westconnex_m4east_aqm_test'
-    }
-  else # development
-    {
-      adapter: 'postgresql',
-      host: 'localhost',
-      username: 'westconnex_m4east_aqm',
-      password: ENV['DEVELOPMENT_DATABASE_PASSWORD'],
-      database: 'westconnex_m4east_aqm_development'
-    }
-  end
-end
-
-DB = Sequel.connect(database_config)
+require './db/connection'
 
 class AqmRecord < Sequel::Model; end

--- a/database.rb
+++ b/database.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_record'
+require 'sequel'
 
 def database_config
   if ENV['RACK_ENV'] == 'production'
@@ -26,26 +26,6 @@ def database_config
   end
 end
 
-ActiveRecord::Base.establish_connection(database_config)
+DB = Sequel.connect(database_config)
 
-class AqmRecord < ActiveRecord::Base; end
-
-unless AqmRecord.table_exists?
-  ActiveRecord::Schema.define do
-    create_table :aqm_records do |t|
-      t.string :location_name
-      t.string :scraped_at
-      t.string :latest_reading_recorded_at
-      t.string :pm2_5_concentration
-      t.string :pm10_concentration
-      t.string :co_concentration
-      t.string :no2_concentration
-      t.string :differential_temperature_lower
-      t.string :differential_temperature_upper
-      t.string :wind_speed
-      t.string :wind_direction
-      t.string :sigma
-    end
-  end
-  AqmRecord.reset_column_information
-end
+class AqmRecord < Sequel::Model; end

--- a/db/connection.rb
+++ b/db/connection.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'sequel'
+
+def database_config
+  if ENV['RACK_ENV'] == 'production'
+    ENV['DATABASE_URL']
+  elsif ENV['RACK_ENV'] == 'test' && ENV['TRAVIS'] == 'true'
+    { adapter: 'postgresql', database: 'travis_ci_test' }
+  elsif ENV['RACK_ENV'] == 'test'
+    {
+      adapter: 'postgresql',
+      host: 'localhost',
+      username: 'westconnex_m4east_aqm',
+      password: ENV['DEVELOPMENT_DATABASE_PASSWORD'],
+      database: 'westconnex_m4east_aqm_test'
+    }
+  else # development
+    {
+      adapter: 'postgresql',
+      host: 'localhost',
+      username: 'westconnex_m4east_aqm',
+      password: ENV['DEVELOPMENT_DATABASE_PASSWORD'],
+      database: 'westconnex_m4east_aqm_development'
+    }
+  end
+end
+
+DB = Sequel.connect(database_config)

--- a/db/migrations/001_initial_schema.rb
+++ b/db/migrations/001_initial_schema.rb
@@ -2,7 +2,7 @@
 
 Sequel.migration do
   change do
-    create_table(:aqm_records) do
+    create_table?(:aqm_records) do
       primary_key :id, type: :Bignum
       String :location_name
       String :scraped_at

--- a/db/migrations/001_initial_schema.rb
+++ b/db/migrations/001_initial_schema.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:aqm_records) do
+      primary_key :id, type: :Bignum
+      String :location_name
+      String :scraped_at
+      String :latest_reading_recorded_at
+      String :pm2_5_concentration
+      String :pm10_concentration
+      String :co_concentration
+      String :no2_concentration
+      String :differential_temperature_lower
+      String :differential_temperature_upper
+      String :wind_speed
+      String :wind_direction
+      String :sigma
+    end
+  end
+end

--- a/db/migrations/002_remove_units_from_records.rb
+++ b/db/migrations/002_remove_units_from_records.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/LineLength
 Sequel.migration do
   up do
     def extract_value(string)
@@ -41,3 +42,4 @@ Sequel.migration do
     end
   end
 end
+# rubocop:enable Metrics/LineLength

--- a/db/migrations/002_remove_units_from_records.rb
+++ b/db/migrations/002_remove_units_from_records.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    def extract_value(string)
+      string&.split(' ')&.first
+    end
+
+    from(:aqm_records).all.each do |record|
+      record.update(
+        pm2_5_concentration: extract_value(record[:pm2_5_concentration]),
+        pm10_concentration: extract_value(record[:pm10_concentration]),
+        co_concentration: extract_value(record[:co_concentration]),
+        no2_concentration: extract_value(record[:no2_concentration]),
+        differential_temperature_lower: extract_value(record[:differential_temperature_lower]),
+        differential_temperature_upper: extract_value(record[:differential_temperature_upper]),
+        wind_speed: extract_value(record[:wind_speed]),
+        wind_direction: extract_value(record[:wind_direction]),
+        sigma: extract_value(record[:sigma])
+      )
+
+      from(:aqm_records).where(id: record[:id]).update(record)
+    end
+  end
+
+  down do
+    from(:aqm_records).all.each do |record|
+      record.update(
+        pm2_5_concentration: record[:pm2_5_concentration] + ' (µg/m³)',
+        pm10_concentration: record[:pm10_concentration] + ' (µg/m³)',
+        co_concentration: record[:co_concentration] + ' (ppm)',
+        no2_concentration: record[:no2_concentration] + ' (ppm)',
+        differential_temperature_lower: record[:differential_temperature_lower] + ' (°C)',
+        differential_temperature_upper: record[:differential_temperature_upper] + ' (°C)',
+        wind_speed: record[:wind_speed] + ' (m/s)',
+        wind_direction: record[:wind_direction] + ' (°)',
+        sigma: record[:sigma] + ' (°)'
+      )
+
+      from(:aqm_records).where(id: record[:id]).update(record)
+    end
+  end
+end

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -10,8 +10,9 @@ describe Sinatra::Application do
 
   describe 'the API' do
     before do
-      AqmRecord.destroy_all
-      AqmRecord.create!(
+      AqmRecord.dataset.destroy
+      AqmRecord.unrestrict_primary_key
+      AqmRecord.create(
         id: 1,
         location_name: 'Haberfield Public School AQM',
         scraped_at: '2018-03-20 12:03:28 +1100',
@@ -26,7 +27,7 @@ describe Sinatra::Application do
         wind_direction: '175.3 (°)',
         sigma: '31.3 (°)'
       )
-      AqmRecord.create!(
+      AqmRecord.create(
         id: 2,
         location_name: 'Allen St AQM',
         scraped_at: '2018-03-20 12:03:32 +1100',


### PR DESCRIPTION
The main goal of this pull request is to resolve #26. To do that it switches from ActiveRecord to Sequel and starts to use Sequel's migrations support.

It includes an initial migration to create the database and a migration that makes the change to the database [we did manually](https://github.com/equivalentideas/westconnex_M4_East_Air_Quality_Monitoring/issues/13#issuecomment-374774800).