### PR TITLE
Change how Rubocop is installed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,14 +8,11 @@ gem 'activerecord'
 gem 'pg'
 gem 'poltergeist'
 gem 'rake'
+gem 'rubocop', require: false
 gem 'sequel'
 gem 'sinatra'
 
 group :development do
   gem 'dotenv'
   gem 'pry'
-end
-
-group :development, :test do
-  gem 'rubocop'
 end


### PR DESCRIPTION
When trying to run rake in production it was complaining about not being
able to load Rubocop. This is because we only included it in the test
and development groups in the Gemfile.

This change moves it into the main part of the Gemfile. We don't really
want Rubocop available in production but this seems like the quickest
and easiest solution for now.

This change also makes it so that Rubocop isn't required, as suggested
in the documentation:

https://github.com/bbatsov/rubocop/tree/v0.54.0#installation