### PR TITLE
Disable Rubocop Metrics/LineLength cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,4 +11,4 @@ Metrics/BlockLength:
 # usual. This is something we might want to fix in the future but we're unlikely
 # to for now.
 Metrics/LineLength:
-  Max: 100
+  Enabled: false


### PR DESCRIPTION
This was complaining about a line in a test I just wrote so now it's too
annoying to keep on. Maybe we want to fix it in the future? I don't
know.