### PR TITLE
Make the name of the CSV download file more useful 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ gem 'sinatra'
 group :development do
   gem 'dotenv'
   gem 'pry'
+  gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
       tilt (~> 2.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.3.0)
@@ -94,6 +95,7 @@ DEPENDENCIES
   rubocop
   sequel
   sinatra
+  timecop
 
 RUBY VERSION
    ruby 2.5.0p0

--- a/app.rb
+++ b/app.rb
@@ -9,9 +9,14 @@ get '/' do
   'Hello world!'
 end
 
+# TODO: Move this to a helper
+def csv_filename
+  Time.now.strftime('%F_%H%M') + '_m4east_air_quality_monitors.csv'
+end
+
 get '/csv' do
   content_type 'application/csv'
-  attachment 'aqm_records.csv'
+  attachment csv_filename
   CSV.generate do |csv|
     csv << AqmRecord.columns # Add header row
     AqmRecord.all.each do |record|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@
 ENV['RACK_ENV'] = 'test'
 require 'minitest/autorun'
 require 'rack/test'
+require 'timecop'
 require_relative '../app'
 
 module Minitest

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -52,5 +52,20 @@ describe Sinatra::Application do
         2,Allen St AQM,2018-03-20 12:03:32 +1100,20 March 2018 11:00:00 AM AEDT,12.0,48.4,0.10,0.009,27.1,26.7,2.8,169.3,32.2
       CSV
     end
+
+    it 'should have a useful filename' do
+      Timecop.freeze(Time.new(2018, 1, 1, 12, 34)) do
+        get '/csv'
+        last_response.header['Content-Disposition'].must_include '2018-01-01_1234_m4east_air_quality_monitors.csv'
+      end
+    end
+
+    describe 'csv_filename' do
+      it 'should include the date and time the file was downloaded' do
+        Timecop.freeze(Time.new(2018, 1, 1, 12, 34)) do
+          csv_filename.must_equal '2018-01-01_1234_m4east_air_quality_monitors.csv'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Includes the date and time the file was downloaded in the filename.

The issue suggested, '_A file name like
201803261243_m4east_air_quality_monitors.csv might be good?_' but I
thought that the jumble of numbers at the start of the filename might be
confusing. Instead I've included separators that I hope make it clearer.