### PR TITLE
Clean database between test with database_cleaner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,7 @@ group :development do
   gem 'pry'
   gem 'timecop'
 end
+
+group :test do
+  gem 'database_cleaner'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
     cliver (0.3.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
+    database_cleaner (1.6.2)
     dotenv (2.2.1)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -87,6 +88,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord
+  database_cleaner
   dotenv
   pg
   poltergeist

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,10 @@ ENV['RACK_ENV'] = 'test'
 require 'minitest/autorun'
 require 'rack/test'
 require 'timecop'
+require 'database_cleaner'
 require_relative '../app'
+
+DatabaseCleaner.strategy = :transaction
 
 module Minitest
   class Spec
@@ -12,6 +15,14 @@ module Minitest
 
     def app
       Sinatra::Application
+    end
+
+    before :each do
+      DatabaseCleaner.start
+    end
+
+    after :each do
+      DatabaseCleaner.clean
     end
   end
 end

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -10,7 +10,6 @@ describe Sinatra::Application do
 
   describe 'the API' do
     before do
-      AqmRecord.dataset.destroy
       AqmRecord.unrestrict_primary_key
       AqmRecord.create(
         id: 1,


### PR DESCRIPTION
This makes it easier to add more tests that interact with the database
without needing to manually flush the database each time.