### PR TITLE
Capture the original 'latest reading' string

### DIFF
--- a/db/migrations/007_add_original_date_string_to_aqm_records.rb
+++ b/db/migrations/007_add_original_date_string_to_aqm_records.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    add_column :aqm_records, :original_reading_datetime_string, String
+
+    from(:aqm_records).all.each do |record|
+      record.update(
+        original_reading_datetime_string: record[:latest_reading_recorded_at]
+      )
+
+      from(:aqm_records).where(id: record[:id]).update(record)
+    end
+  end
+end

--- a/lib/scraper.rb
+++ b/lib/scraper.rb
@@ -27,6 +27,7 @@ class Scraper
 
       record[:scraped_at] = Time.now.to_s
       record[:latest_reading_recorded_at] = presence(capybara.find('table thead').text.split('at: ').last)
+      record[:original_reading_datetime_string] = record[:latest_reading_recorded_at]
 
       key_rows = capybara.all('tbody th').map { |th| tableize(th.text) }
       value_rows = capybara.all('tbody td').map { |td| extract_value(td.text) }

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -24,7 +24,8 @@ describe Sinatra::Application do
         differential_temperature_upper_deg_c: '25.8',
         wind_speed_metres_per_second: '3.0',
         wind_direction_deg_true_north: '175.3',
-        sigma_deg_true_north: '31.3'
+        sigma_deg_true_north: '31.3',
+        original_reading_datetime_string: '20 March 2018 11:00:00 AM AEDT'
       )
       AqmRecord.create(
         id: 2,
@@ -39,16 +40,17 @@ describe Sinatra::Application do
         differential_temperature_upper_deg_c: '26.7',
         wind_speed_metres_per_second: '2.8',
         wind_direction_deg_true_north: '169.3',
-        sigma_deg_true_north: '32.2'
+        sigma_deg_true_north: '32.2',
+        original_reading_datetime_string: '20 March 2018 11:00:00 AM AEDT'
       )
     end
 
     it 'should supply a CSV of all of the data' do
       get '/csv'
       last_response.body.must_equal <<~CSV
-        id,location_name,scraped_at,latest_reading_recorded_at,pm2_5_concentration_ug_per_m3,pm10_concentration_ug_per_m3,co_concentration_ppm,no2_concentration_ppm,differential_temperature_lower_deg_c,differential_temperature_upper_deg_c,wind_speed_metres_per_second,wind_direction_deg_true_north,sigma_deg_true_north
-        2,Allen St AQM,2018-03-20 01:03:28 UTC,20 March 2018 11:00:00 AM AEDT,12.0,48.4,0.1,0.009,27.1,26.7,2.8,169.3,32.2
-        1,Haberfield Public School AQM,2018-03-20 01:03:32 UTC,20 March 2018 11:00:00 AM AEDT,17.0,44.1,0.07,0.006,26.9,25.8,3.0,175.3,31.3
+        id,location_name,scraped_at,latest_reading_recorded_at,pm2_5_concentration_ug_per_m3,pm10_concentration_ug_per_m3,co_concentration_ppm,no2_concentration_ppm,differential_temperature_lower_deg_c,differential_temperature_upper_deg_c,wind_speed_metres_per_second,wind_direction_deg_true_north,sigma_deg_true_north,original_reading_datetime_string
+        2,Allen St AQM,2018-03-20 01:03:28 UTC,20 March 2018 11:00:00 AM AEDT,12.0,48.4,0.1,0.009,27.1,26.7,2.8,169.3,32.2,20 March 2018 11:00:00 AM AEDT
+        1,Haberfield Public School AQM,2018-03-20 01:03:32 UTC,20 March 2018 11:00:00 AM AEDT,17.0,44.1,0.07,0.006,26.9,25.8,3.0,175.3,31.3,20 March 2018 11:00:00 AM AEDT
       CSV
     end
 


### PR DESCRIPTION
So that we can re-do or audit our conversation of the `latest_reading_recorded_at` data in the future, we want to store what we've saved so far, and what they present from now on, in it's own column.

These two commits:

* add the migration to create the column and populate the existing rows
* updated the scraping code to collect this data on future runs

See #32 

@henare could you review this please?