### PR TITLE
Change application timezone to UTC+10

### DIFF
--- a/db/connection.rb
+++ b/db/connection.rb
@@ -27,5 +27,6 @@ def database_config
 end
 
 Sequel.database_timezone = :utc
+Sequel.application_timezone = :local
 
 DB = Sequel.connect(database_config)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,9 @@ module Minitest
     end
 
     before :each do
+      # Set timezone to UTC+10 as this is what we use on the server
+      ENV['TZ'] = 'Etc/GMT-10'
+
       DatabaseCleaner.start
     end
 

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -49,8 +49,8 @@ describe Sinatra::Application do
       get '/csv'
       last_response.body.must_equal <<~CSV
         id,location_name,scraped_at,latest_reading_recorded_at,pm2_5_concentration_ug_per_m3,pm10_concentration_ug_per_m3,co_concentration_ppm,no2_concentration_ppm,differential_temperature_lower_deg_c,differential_temperature_upper_deg_c,wind_speed_metres_per_second,wind_direction_deg_true_north,sigma_deg_true_north,latest_reading_recorded_at_raw
-        2,Allen St AQM,2018-03-20 01:03:28 UTC,2018-03-20 01:00:00 UTC,12.0,48.4,0.1,0.009,27.1,26.7,2.8,169.3,32.2,20 March 2018 11:00:00 AM AEDT
-        1,Haberfield Public School AQM,2018-03-20 01:03:32 UTC,2018-03-20 01:00:00 UTC,17.0,44.1,0.07,0.006,26.9,25.8,3.0,175.3,31.3,20 March 2018 11:00:00 AM AEDT
+        2,Allen St AQM,2018-03-20 11:03:28 +1000,2018-03-20 11:00:00 +1000,12.0,48.4,0.1,0.009,27.1,26.7,2.8,169.3,32.2,20 March 2018 11:00:00 AM AEDT
+        1,Haberfield Public School AQM,2018-03-20 11:03:32 +1000,2018-03-20 11:00:00 +1000,17.0,44.1,0.07,0.006,26.9,25.8,3.0,175.3,31.3,20 March 2018 11:00:00 AM AEDT
       CSV
     end
 


### PR DESCRIPTION
Fixes #50 by telling Sequel to use the local timezone. We'll set Heroku to UTC+10 and then the application will convert to and from UTC+10 (the timezone we think the source site uses).

When we deploy this we need to configure Heroku by running this and restarting the application:

    heroku config:add TZ="Etc/GMT-10"