### PR TITLE
Remove activerecord gem as we switched to Sequel ages ago

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 
 ruby '2.5.0'
 
-gem 'activerecord'
 gem 'pg'
 gem 'rake'
 gem 'rubocop', require: false
@@ -13,6 +12,7 @@ gem 'sinatra'
 
 group :development do
   gem 'dotenv'
+  gem 'minitest'
   gem 'pry'
   gem 'rack-test'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.1.5)
-      activesupport (= 5.1.5)
-    activerecord (5.1.5)
-      activemodel (= 5.1.5)
-      activesupport (= 5.1.5)
-      arel (~> 8.0)
-    activesupport (5.1.5)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    arel (8.0.0)
     ast (2.4.0)
     coderay (1.1.2)
-    concurrent-ruby (1.0.5)
     database_cleaner (1.6.2)
     dotenv (2.2.1)
-    i18n (0.9.5)
-      concurrent-ruby (~> 1.0)
     method_source (0.9.0)
     minitest (5.11.3)
     mustermann (1.0.2)
@@ -52,20 +37,17 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.1)
       tilt (~> 2.0)
-    thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.1)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
     unicode-display_width (1.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord
   database_cleaner
   dotenv
+  minitest
   pg
   pry
   rack-test


### PR DESCRIPTION
Also explicitly add the minitest gem to the testing group so that our
test suite still works (it was included in our bundle as part of
activerecord previously).

Fixes #59.