### PR TITLE
Don't explicitly specify Heroku app name in README commands 

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ bundle exec dotenv rake
 Capture and download the Postgres database from Heroku:
 
 ```
-heroku pg:backups:capture --app $heroku_app_name
-heroku pg:backups:download --app $heroku_app_name
+heroku pg:backups:capture
+heroku pg:backups:download
 ```
 
 You'll now have a file `latest.dump`.
@@ -211,13 +211,13 @@ Heroku injects it's own `ENV['DATABASE_URL']`.
 ### Running database migrations in production
 
 ```
-heroku run 'bundle exec rake db:migrate' --app $heroku_app_name
+heroku run 'bundle exec rake db:migrate'
 ```
 
 ### Access the production data
 
 ```
-heroku pg:psql --app $heroku_app_name
+heroku pg:psql
 
 > SELECT * FROM aqm_records;
 ```
@@ -227,5 +227,5 @@ heroku pg:psql --app $heroku_app_name
 You can view the logs from the [Heroku scheduler](https://devcenter.heroku.com/articles/scheduler#inspecting-output) with:
 
 ```
-heroku logs --app $heroku_app_name --ps scheduler
+heroku logs --ps scheduler
 ```

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Heroku injects it's own `ENV['DATABASE_URL']`.
 ### Running database migrations in production
 
 ```
-heroku run 'bundle exec rake db:migrate'
+heroku run rake db:migrate
 ```
 
 ### Access the production data


### PR DESCRIPTION
It shouldn't be necessary if the Heroku CLI is configured correctly.

Making this change after @equivalentideas mentioned we should in
response to my comment: https://github.com/equivalentideas/westconnex_M4_East_Air_Quality_Monitoring/commit/3146069bc2d0bab7c4d19e65fda51ab75f0da34e#r28725444