### PR TITLE
Add basic Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec rackup config.ru -p $PORT


### PR DESCRIPTION
This does exactly what Heroku is already doing, which is using WEBrick.
Heroku strongly recommends not using WEBrick:

https://devcenter.heroku.com/articles/ruby-default-web-server

But let's change that later, if we want to.

Fixes #33.

## After deployment

Ensure the webserver is still starting and running OK as that's what we're potentially changing here.