### PR TITLE
Allow access to better_errors from Docker private IP ranges

### DIFF
--- a/config/app_config.rb
+++ b/config/app_config.rb
@@ -5,6 +5,7 @@ require 'better_errors' unless %w[production test].include? ENV['RACK_ENV']
 configure :development do
   use BetterErrors::Middleware
   BetterErrors.application_root = __dir__
+  BetterErrors::Middleware.allow_ip! '172.16.0.0/12'
 end
 
 require './db/connection'


### PR DESCRIPTION
This is because I'm using Docker locally for development